### PR TITLE
Use the types from prepare for execute

### DIFF
--- a/src/erlcql_client.erl
+++ b/src/erlcql_client.erl
@@ -349,7 +349,7 @@ apply_prepare(_Pid, []) ->
     {ok, void};
 apply_prepare(Pid, [{Name, Query} | Queries]) ->
     case prepare(Pid, Query, Name) of
-        {ok, _} ->
+        {ok, _, _} ->
             apply_prepare(Pid, Queries);
         {error, _Reason} ->
             {error, prepare_failed}

--- a/src/erlcql_convert.erl
+++ b/src/erlcql_convert.erl
@@ -133,6 +133,8 @@ to_binary(Values) ->
       Binary :: iodata().
 to_binary(_, null) ->
     null;
+to_binary(_, undefined) ->
+    null;
 to_binary(ascii, Binary) ->
     Binary;
 to_binary(bigint, Int) ->

--- a/src/erlcql_decode.erl
+++ b/src/erlcql_decode.erl
@@ -393,9 +393,10 @@ set_keyspace(<<Length:?SHORT, Keyspace:Length/binary>>) ->
 %% Result: Prepared
 
 -spec prepared(binary()) -> prepared().
-prepared(<<Length:?SHORT, QueryId:Length/binary, _Metadata/binary>>) ->
-    %% {ColumnCount, ColumnSpecs, <<>>} = metadata(Metadata),
-    {ok, QueryId}.
+prepared(<<Length:?SHORT, QueryId:Length/binary, Metadata/binary>>) ->
+    {_ColumnCount, ColumnSpecs, <<>>} = metadata(Metadata),
+    {_, ColumnTypes} = lists:unzip(ColumnSpecs),
+    {ok, QueryId, ColumnTypes}.
 
 %% Result: Schema change
 


### PR DESCRIPTION
Cassandra knows what the types are and returns them to us, so why throw that away and pass them in manually?
